### PR TITLE
Use --side  option instead of hardcoded --lowvram and --medvram

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@
 
 --model_path		Name of the sdxl model from huggingface   (the default model example: --model_path stablediffusionapi/juggernaut-xl-v8     diffuser model you can find here: https://huggingface.co/stablediffusionapi/juggernaut-xl-v8
 
---medvram			Medium vram settings, uses around 13GB, max image resolution of 1024
-
---lowvram			Low vram settings, uses a bit less than 13GB, max image resolution of 832
+--size			    Setup max and min size of image. Default is `1280 1024`, uses around 13GB. If you want to use less, set: `--size 832 640`, or your own values.
 
 
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 --model_path		Name of the sdxl model from huggingface   (the default model example: --model_path stablediffusionapi/juggernaut-xl-v8     diffuser model you can find here: https://huggingface.co/stablediffusionapi/juggernaut-xl-v8
 
---size			    Setup max and min size of image. Default is `1280 1024`, uses around 13GB. If you want to use less, set: `--size 832 640`, or your own values.
+--side			    Setup max and min size of image. Default is `1280 1024`, uses around 13GB. If you want to use less, set: `--side 832 640`, or your own values.
 
 
 

--- a/app.py
+++ b/app.py
@@ -420,8 +420,6 @@ if __name__ == '__main__':
     parser.add_argument('--server_port', type=int, default=7860, help='Server port')
     parser.add_argument('--share', action='store_true', help='Share the Gradio UI')
     parser.add_argument('--model_path', type=str, default='stablediffusionapi/juggernaut-xl-v8', help='Base model path')
-    parser.add_argument('--medvram', action='store_true', help='Medium VRAM settings')
-    parser.add_argument('--lowvram', action='store_true', help='Low VRAM settings')
     parser.add_argument('--side', type=int, nargs=2, default=[1280, 1024], help='Maximum and minimum side resolution')
 
     args = parser.parse_args()

--- a/app.py
+++ b/app.py
@@ -422,18 +422,12 @@ if __name__ == '__main__':
     parser.add_argument('--model_path', type=str, default='stablediffusionapi/juggernaut-xl-v8', help='Base model path')
     parser.add_argument('--medvram', action='store_true', help='Medium VRAM settings')
     parser.add_argument('--lowvram', action='store_true', help='Low VRAM settings')
+    parser.add_argument('--side', type=int, nargs=2, default=[1280, 1024], help='Maximum and minimum side resolution')
 
     args = parser.parse_args()
     
     # Default values for max_side and min_side
-    max_side = 1280
-    min_side = 1024
-
-    # Adjust max_side and min_side based on the arguments
-    if args.medvram:
-        max_side, min_side = 1024, 832
-    elif args.lowvram:
-        max_side, min_side = 832, 640
+    max_side, min_side = args.side
 
     # Display the current resolution settings
     print(f"Current resolution settings: max_side = {max_side}, min_side = {min_side}")


### PR DESCRIPTION
Just it is easier to use.

Also it would be useful to split last 'run' command in colab in separate cell to avoid installation after args changing.